### PR TITLE
Fixed RangeLength Validators

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -112,7 +112,7 @@ exports.range = function (min, max, message) {
 exports.minlength = function (val, message) {
     var msg = message || 'Please enter at least %s characters.';
     return function (form, field, callback) {
-        if (field.data.length >= val) {
+        if (field.data.toString().length >= val) {
             callback();
         } else {
             callback(format(msg, val));
@@ -123,7 +123,7 @@ exports.minlength = function (val, message) {
 exports.maxlength = function (val, message) {
     var msg = message || 'Please enter no more than %s characters.';
     return function (form, field, callback) {
-        if (field.data.length <= val) {
+        if (field.data.toString().length <= val) {
             callback();
         } else {
             callback(format(msg, val));
@@ -134,7 +134,7 @@ exports.maxlength = function (val, message) {
 exports.rangelength = function (min, max, message) {
     var msg = message || 'Please enter a value between %s and %s characters long.';
     return function (form, field, callback) {
-        if (field.data.length >= min && field.data.length <= max) {
+        if (field.data.toString().length >= min && field.data.toString().length <= max) {
             callback();
         } else {
             callback(format(msg, min, max));


### PR DESCRIPTION
The minLength, maxLength, and RangeLength validators were not working on number inputs. Lets say we wanted to check if '12345' had a minimum of 4 digits, minLength would fail in this case because field.data.length would be undefined for a number data type. Performing a toString() on it fixes this.